### PR TITLE
Fix having to source twice

### DIFF
--- a/pontus_sim/env-hooks/pontus_sim.sh.in
+++ b/pontus_sim/env-hooks/pontus_sim.sh.in
@@ -1,7 +1,7 @@
-# Documentation implies that GZ Garden should use the GZ SIM resource path variable but it seems like it currently is using the IGN GAZEBO variable. For now we will just set both
-ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
-ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+# Documentation implies that GZ Garden should use the GZ SIM resource path variable but it seems like it currently is using the IGN GAZEBO variable. For now we will manually override the GZ_SIM path to match the IGN path.
 
-ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
-ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
 
+#ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+
+export GZ_SIM_RESOURCE_PATH=$IGN_GAZEBO_RESOURCE_PATH

--- a/pontus_sim/env-hooks/pontus_sim.sh.in
+++ b/pontus_sim/env-hooks/pontus_sim.sh.in
@@ -1,6 +1,15 @@
 # Documentation implies that GZ Garden should use the GZ SIM resource path variable but it seems like it currently is using the IGN GAZEBO variable. For now we will manually override the GZ_SIM path to match the IGN path.
 
-ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+RESOURCE_PATH="$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+
+
+if [ -z "${IGN_GAZEBO_RESOURCE_PATH}" ]; then
+    export IGN_GAZEBO_RESOURCE_PATH="$RESOURCE_PATH"
+    echo "not set"
+else
+    ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$RESOURCE_PATH"
+    echo "already set"
+fi
 
 #ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
 

--- a/pontus_sim/env-hooks/pontus_sim.sh.in
+++ b/pontus_sim/env-hooks/pontus_sim.sh.in
@@ -1,2 +1,7 @@
+# Documentation implies that GZ Garden should use the GZ SIM resource path variable but it seems like it currently is using the IGN GAZEBO variable. For now we will just set both
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$IGN_GAZEBO_RESOURCE_PATH:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+

--- a/pontus_sim/env-hooks/pontus_sim.sh.in
+++ b/pontus_sim/env-hooks/pontus_sim.sh.in
@@ -5,10 +5,8 @@ RESOURCE_PATH="$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURREN
 
 if [ -z "${IGN_GAZEBO_RESOURCE_PATH}" ]; then
     export IGN_GAZEBO_RESOURCE_PATH="$RESOURCE_PATH"
-    echo "not set"
 else
     ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$RESOURCE_PATH"
-    echo "already set"
 fi
 
 #ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds:$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"


### PR DESCRIPTION
For whatever reason the documentation for Gazebo Garden implies that it should be using the `GZ_SIM_RESOURCE_PATH` variable but instead it seems like it still uses the `IGN_GAZEBO_RESOURCE_PATH`.  For now the env-hook just sets both and when it eventually gets updated we can remove the unnecessary environment variable.