### PR TITLE
Add thruster scaling to fix thruster saturation

### DIFF
--- a/pontus_controller/pontus_controller/PID.py
+++ b/pontus_controller/pontus_controller/PID.py
@@ -1,6 +1,6 @@
 class PID:
 
-    def __init__(self, kp, ki, kd):
+    def __init__(self, kp, ki, kd, windup_max=None):
         self.kp = kp
         self.ki = ki
         self.kd = kd
@@ -8,20 +8,28 @@ class PID:
         self.prev_err = 0.0
         self.integral = 0.0
 
+        # max magnitude to cap the integral
+        self.windup_max = windup_max
+
     def __call__(self, err, dt):
 
-      dt = dt.nanoseconds * 1e-9 # Convert ROS duration to seconds
+        dt = dt.nanoseconds * 1e-9 # Convert ROS duration to seconds
 
-      # Check for valid dt
-      if dt <= 0:
-          print("invalid dt")
-          return 0.0
+        # Check for valid dt
+        if dt <= 0:
+            print("invalid dt")
+            return 0.0
 
-      self.integral += err * dt # compute integral of the error over time
-      d_err = (err - self.prev_err) / dt # compute derivative of the error
+        self.integral += err * dt # compute integral of the error over time
 
-      u = (self.kp * err) + (self.ki * self.integral) + (self.kd * d_err) # compute the output
+        # Clamp the integral term so it doesn't grow too large
+        if self.windup_max != None:
+            self.integral = max(-self.windup_max, min(self.integral, self.windup_max))
 
-      self.prev_err = err
+        d_err = (err - self.prev_err) / dt # compute derivative of the error
 
-      return u
+        u = (self.kp * err) + (self.ki * self.integral) + (self.kd * d_err) # compute the output
+
+        self.prev_err = err
+
+        return u

--- a/pontus_controller/pontus_controller/thruster_controller.py
+++ b/pontus_controller/pontus_controller/thruster_controller.py
@@ -137,15 +137,18 @@ class ThrusterController(Node):
         # vertical thrusters to decrease their output making us sink
         for i in range(2):
 
+            start = 4*i
+            end = (4*i) + 4
+
             # Calculate the highest commanded output thrust so we can scale
             # all of the thrusters down if we exceed max thrust.
             # This helps pevent issues with multiple thrusters being saturated
             # leading to the vehicle moving in unintended directions
-            max_commanded = np.max(thruster_forces)
+            max_commanded = np.max(thruster_forces[start:end])
             scale = (max_commanded / self.max_thrust) if max_commanded > self.max_thrust else 1.0
 
             # Publish thruster commands
-            for index in range(4*i, (4*i) + 4):
+            for index in range(start, end):
                 self.thrusters[index].set_thrust(thruster_forces[index] / scale)
 
 

--- a/pontus_controller/pontus_controller/thruster_controller.py
+++ b/pontus_controller/pontus_controller/thruster_controller.py
@@ -14,11 +14,10 @@ from std_msgs.msg import Float64
 class ThrusterController(Node):
 
     class Thruster:
-        def __init__(self, Node, thruster_id,  pos, quaternion):
+        def __init__(self, Node, thruster_id, max_thrust,  pos, quaternion):
             self.pub = Node.create_publisher(Float64, 'pontus/thruster_' + str(thruster_id) + '/cmd_thrust', 10)
 
-            # TODO: Make this a parameter or something
-            self.max_thrust = 52
+            self.max_thrust = max_thrust
 
             q = quaternion
             axis = np.array([0, 0, 1]) # Our thrusters rotate the propeller around the z axis
@@ -70,6 +69,7 @@ class ThrusterController(Node):
 
         #TODO: make these parameters or something
         self.vehicle_name = 'pontus'
+        self.max_thrust = 52.0
 
         #TODO: These could be pulled from the robot description topic
 
@@ -132,9 +132,21 @@ class ThrusterController(Node):
         # Calculate individual thruster force to generate desired total force
         thruster_forces = self.inverse_jacobian.dot(force_torque)
 
-        # Publish thruster commands
-        for index, thruster in enumerate(self.thrusters):
-            thruster.set_thrust(thruster_forces[index])
+        # Handle matching sets of thrusters (vertical and horizontal) independently.
+        # Otherwise trying to command full forward velocity could cause our 
+        # vertical thrusters to decrease their output making us sink
+        for i in range(2):
+
+            # Calculate the highest commanded output thrust so we can scale
+            # all of the thrusters down if we exceed max thrust.
+            # This helps pevent issues with multiple thrusters being saturated
+            # leading to the vehicle moving in unintended directions
+            max_commanded = np.max(thruster_forces)
+            scale = (max_commanded / self.max_thrust) if max_commanded > self.max_thrust else 1.0
+
+            # Publish thruster commands
+            for index in range(4*i, (4*i) + 4):
+                self.thrusters[index].set_thrust(thruster_forces[index] / scale)
 
 
     def generate_thrusters(self):
@@ -164,7 +176,7 @@ class ThrusterController(Node):
                                       transform.transform.rotation.z,
                                       transform.transform.rotation.w])
 
-            self.thrusters.append(self.Thruster(self, i, pos, quaternion))
+            self.thrusters.append(self.Thruster(self, i, self.max_thrust, pos, quaternion))
             self.jacobian_matrix[:, i] = self.thrusters[i].jacobian_column
 
         # Eliminate small values

--- a/pontus_controller/pontus_controller/velocity_controller.py
+++ b/pontus_controller/pontus_controller/velocity_controller.py
@@ -22,15 +22,15 @@ class VelocityNode(Node):
 
         # TODO: Tune these
         self.pid_linear = [
-          PID(2, 1, 0), # X
-          PID(2, 1, 0), # Y
-          PID(2, 1, 0)  # Z
+          PID(2, 1, 0, 2), # X
+          PID(2, 1, 0, 2), # Y
+          PID(2, 1, 0, 2)  # Z
         ]
 
         self.pid_angular = [
-          PID(2, 0, 0), # R
-          PID(2, 0, 0), # P
-          PID(2, 0, 0)  # Y
+          PID(2, 0, 0, 2), # R
+          PID(2, 0, 0, 2), # P
+          PID(2, 0, 0, 2)  # Y
         ]
 
         # ROS infrastructure


### PR DESCRIPTION
Without thruster scaling when the vehicle tries to command over max thrust the values get clamped but if you need differing amounts of thrust from various thrusters the values can all get clamped to the same output. This PR adds functionality to independently scale the horizontal and vertical thruster sets by the highest commanded value before the values get clamped.

I am a little worried that this could cause issues with the velocity controller integral terms if we ever add any since the commanded accelerations are effectively getting reduced. If we know for sure we would never want to separately command a body acceleration we might want to merge the thruster_controller and velocity_controller nodes to allow for something like feedback anti-windup where we adjust the integral using the scaled commanded output.