### PR TITLE
Add compressed yolo debug publisher

### DIFF
--- a/pontus_perception/launch/perception.launch.py
+++ b/pontus_perception/launch/perception.launch.py
@@ -35,7 +35,8 @@ def generate_launch_description():
             remappings=[
                 ('input', '/pontus/camera_2/image_rect_color'),
                 ('results', '/pontus/camera_2/yolo_results'),
-                ('yolo_debug', '/pontus/camera_2/yolo_debug')
+                ('yolo_debug', '/pontus/camera_2/yolo_debug'),
+                ('yolo_debug/compressed', '/pontus/camera_2/yolo_debug/compressed')
             ]
         ),
         # Not needed if using disparity map
@@ -50,7 +51,8 @@ def generate_launch_description():
             remappings=[
                 ('input', '/pontus/camera_3/image_rect_color'),
                 ('results', '/pontus/camera_3/yolo_results'),
-                ('yolo_debug', '/pontus/camera_3/yolo_debug')
+                ('yolo_debug', '/pontus/camera_3/yolo_debug'),
+                ('yolo_debug/compressed', '/pontus/camera_3/yolo_debug/compressed')
             ]
         ),
         Node(

--- a/pontus_perception/pontus_perception/yolo_node.py
+++ b/pontus_perception/pontus_perception/yolo_node.py
@@ -1,6 +1,6 @@
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 from pontus_msgs.msg import YOLOResultArray, YOLOResult
 import cv2
 from cv_bridge import CvBridge
@@ -40,6 +40,11 @@ class YOLONode(Node):
         self.image_pub = self.create_publisher(
             Image,
             'yolo_debug',
+            10
+        )
+        self.image_pub_compressed = self.create_publisher(
+            CompressedImage,
+            'yolo_debug/compressed',
             10
         )
         self.results_pub = self.create_publisher(
@@ -91,7 +96,9 @@ class YOLONode(Node):
 
         self.results_pub.publish(result_array)
         ros_image = self.cv_bridge.cv2_to_imgmsg(bgr, encoding='bgr8')
+        compressed_image = self.cv_bridge.cv2_to_compressed_imgmsg(bgr)
         self.image_pub.publish(ros_image)
+        self.image_pub_compressed.publish(compressed_image)
 
 
 def main(args: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
During testing we would like to look at the yolo debug. Best practice for this is to view compressed data stream to prevent bandwidth issues and low latency.